### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,87 +5,44 @@ A go (golang) implementation of Java [KeyStore][1] encoder/decoder
 
 Take into account that JKS assumes that private keys are PKCS8 encoded.
 
-### Example
+## Example
 
-```go
-package main
+For examples explore [examples](examples) directory
 
-import (
-	"log"
-	"os"
-	"reflect"
+## Used by
 
-	"github.com/pavlo-v-chernykh/keystore-go/v4"
-)
+[cert-manager/cert-manager][2]
 
-func readKeyStore(filename string, password []byte) keystore.KeyStore {
-	f, err := os.Open(filename)
-	if err != nil {
-		log.Fatal(err)
-	}
+[yugabyte/yugabyte-db][3]
 
-	defer func() {
-		if err := f.Close(); err != nil {
-			log.Fatal(err)
-		}
-	}()
+[banzaicloud/koperator][4]
 
-	ks := keystore.New()
-	if err := ks.Load(f, password); err != nil {
-		log.Fatal(err) //nolint: gocritic
-	}
+[paketo-buildpacks/spring-boot][5]
 
-	return ks
-}
+[paketo-buildpacks/libjvm][6]
 
-func writeKeyStore(ks keystore.KeyStore, filename string, password []byte) {
-	f, err := os.Create(filename)
-	if err != nil {
-		log.Fatal(err)
-	}
+[paketo-buildpacks/graalvm][7]
 
-	defer func() {
-		if err := f.Close(); err != nil {
-			log.Fatal(err)
-		}
-	}()
+[arangodb/arangosync-client][8]
 
-	err = ks.Store(f, password)
-	if err != nil {
-		log.Fatal(err) //nolint: gocritic
-	}
-}
-
-func zeroing(buf []byte) {
-	for i := range buf {
-		buf[i] = 0
-	}
-}
-
-func main() {
-	password := []byte{'p', 'a', 's', 's', 'w', 'o', 'r', 'd'}
-	defer zeroing(password)
-	
-	ks1 := readKeyStore("keystore.jks", password)
-
-	writeKeyStore(ks1, "keystore2.jks", password)
-
-	ks2 := readKeyStore("keystore2.jks", password)
-
-	log.Printf("is equal: %v\n", reflect.DeepEqual(ks1, ks2))
-}
-```
-
-For more examples explore [examples](examples) dir
+and [others][9]
 
 ## Development
 
-1. Install [go][2]
-2. Install [golangci-lint][3]
+1. Install [go][10]
+2. Install [golangci-lint][11]
 3. Clone the repo `git clone git@github.com:pavlo-v-chernykh/keystore-go.git`
 4. Go to the project dir `cd keystore-go`
 5. Run `make`  to format, test and lint
 
 [1]: https://docs.oracle.com/javase/7/docs/technotes/guides/security/crypto/CryptoSpec.html#KeyManagement
-[2]: https://golang.org
-[3]: https://github.com/golangci/golangci-lint
+[2]: https://github.com/cert-manager/cert-manager
+[3]: https://github.com/yugabyte/yugabyte-db
+[4]: https://github.com/banzaicloud/koperator
+[5]: https://github.com/paketo-buildpacks/spring-boot
+[6]: https://github.com/paketo-buildpacks/libjvm
+[7]: https://github.com/paketo-buildpacks/graalvm
+[8]: https://github.com/arangodb/arangosync-client
+[9]: https://github.com/pavlo-v-chernykh/keystore-go/network/dependents
+[10]: https://golang.org
+[11]: https://github.com/golangci/golangci-lint


### PR DESCRIPTION
Incorporate the 'Used by' section due to a recent policy change. This section is now exclusively available for packages with over 100 dependents. For more details, refer to the GitHub documentation on https://docs.github.com/en/code-security/supply-chain-security/understanding-your-software-supply-chain/exploring-the-dependencies-of-a-repository#changing-the-used-by-package